### PR TITLE
Include file version info in the native assembly

### DIFF
--- a/CompressedFileViewer/CompressedFileViewer.plugin.csproj
+++ b/CompressedFileViewer/CompressedFileViewer.plugin.csproj
@@ -91,6 +91,16 @@
 		<NppDir>$(NppDir64)</NppDir>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<!-- https://github.com/AaronRobinsonMSFT/DNNE/issues/197#issuecomment-2621208585 -->
+		<Win32Resources>$(MSBuildProjectDirectory)\$(BaseIntermediateOutputPath)$(DnneNativeBinaryName).res</Win32Resources>
+		<DnneLinkerUserFlags>$(Win32Resources)</DnneLinkerUserFlags>
+	</PropertyGroup>
+
+	<Target Name="CompileWin32Resources" BeforeTargets="CoreCompile" Condition="!Exists('$(Win32Resources)')">
+		<Exec Command="rc.exe /fo $(Win32Resources) $(MSBuildProjectDirectory)\$(DnneNativeBinaryName).rc"/>
+	</Target>
+
 	<Target Name="CopyFiles" AfterTargets="PostBuildEvent" Condition=" Exists('$(NppDir)\plugins') AND '$(NppDir)' != '' ">
 		<ItemGroup>
 			<Binaries Include="$(ProjectDir)$(OutDir)**\*.*" />

--- a/CompressedFileViewer/CompressedFileViewer.rc
+++ b/CompressedFileViewer/CompressedFileViewer.rc
@@ -1,0 +1,33 @@
+#include <winres.h>
+
+#define ASSEMBLY_FILE_VERSION "5.1.0.0"
+#define ASSEMBLY_FILE_VERSION_WORDS 5, 1, 0, 0
+
+1 VERSIONINFO
+  FILEVERSION ASSEMBLY_FILE_VERSION_WORDS
+  PRODUCTVERSION ASSEMBLY_FILE_VERSION_WORDS
+  FILEOS (VOS_NT | VOS__WINDOWS32)
+  FILETYPE VFT_DLL
+  FILESUBTYPE 0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904e4"
+    BEGIN
+      VALUE "Comments", "This is a Notepad++ plugin to open and store files in gzip, bzip2, xz, zstd or brotli format."
+      VALUE "CompanyName", "Pascal Krenckel"
+      VALUE "FileDescription", "CompressedFileViewer"
+      VALUE "FileVersion", ASSEMBLY_FILE_VERSION
+      VALUE "InternalName", "CompressedFileViewer.dll"
+      VALUE "LegalCopyright", "Copyright \251 Pascal Krenckel 2026"
+      VALUE "OriginalFilename", "CompressedFileViewer.dll"
+      VALUE "ProductName",  "CompressedFileViewer"
+      VALUE "ProductVersion", ASSEMBLY_FILE_VERSION
+
+    END
+  END
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x409, 1200
+  END
+END


### PR DESCRIPTION
The actual version info is up to you, of course; this is just a minimal patch to unblock your PR.